### PR TITLE
chore: update GitHub Actions to use latest versions of checkout

### DIFF
--- a/.github/workflows/publish.create.component.yml
+++ b/.github/workflows/publish.create.component.yml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.12.0
           registry-url: https://registry.npmjs.org/
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
 

--- a/.github/workflows/publish.custom.form.field.config.yml
+++ b/.github/workflows/publish.custom.form.field.config.yml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.12.0
           registry-url: https://registry.npmjs.org/
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
 

--- a/.github/workflows/publish.custom.form.field.scripts.yml
+++ b/.github/workflows/publish.custom.form.field.scripts.yml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.12.0
           registry-url: https://registry.npmjs.org/
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
 

--- a/.github/workflows/publish.sdk.yml
+++ b/.github/workflows/publish.sdk.yml
@@ -15,20 +15,21 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: setup node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
                   registry-url: https://registry.npmjs.org/
 
             - name: setup pnpm
-              uses: pnpm/action-setup@v2.1.0
+              uses: pnpm/action-setup@v4
               with:
                   version: latest
-                  run_install: |
-                      - args: [--filter=@kissflow/lowcode-client-sdk, --no-lockfile, --strict-peer-dependencies=false]
+
+            - name: install dependencies
+              run: pnpm install --filter=@kissflow/lowcode-client-sdk --no-lockfile --strict-peer-dependencies=false
 
             - name: git config
               run: |


### PR DESCRIPTION
chore: update GitHub Actions to use latest versions of checkout, setup-node, and pnpm

## Checklist

-   [ ] Added a new class/method in SDK
    -   [ ] Updated version in `package.json`
    -   [ ] Verified `.d.ts` file for new class/method.
    -   [ ] Covered new changes in docs.
    -   [ ] Covered new changes in snippets.
-   [ ] SDK Issue fix PR
    -   [ ] Updated version in `package.json`
    -   [ ] Doesn't affect the previous method signatures.
    -   [ ] Affects the method signature
        - [ ] Changes are conveyed.
        - [ ] Made changes in docs for updated signature.
-   [ ] Documentation updates

## Details of the Feature / Issue

<!-- Enter Overview of the feature / issue ticket -->
